### PR TITLE
Removing project dependencies from WixProj

### DIFF
--- a/Packager/Product.wxs
+++ b/Packager/Product.wxs
@@ -40,7 +40,7 @@
   <Fragment>
     <ComponentGroup Id="ProductComponents" Directory="APPLICATIONFOLDER">
       <Component Id="TunnelRelayUI" Guid="4ECA0543-FA69-4317-ADCC-5E9BE7AB54C5">
-        <File Id="TunnelRelayUIExe" Source="$(var.TunnelRelay.TargetPath)" DiskId="1" KeyPath="yes">
+        <File Id="TunnelRelayUIExe" Source="..\TunnelRelay\bin\$(var.Configuration)\TunnelRelay.exe" DiskId="1" KeyPath="yes">
           <Shortcut
             Id="TunnelRelayUIExeShortcut"
             Name="Tunnel Relay"
@@ -48,51 +48,51 @@
             Directory="DesktopFolder"
             Advertise="yes"
             WorkingDirectory="APPLICATIONFOLDER">
-            <Icon Id="TunnelRelayIcon.exe" SourceFile="$(var.TunnelRelay.TargetPath)" />
+            <Icon Id="TunnelRelayIcon.exe" SourceFile="..\TunnelRelay\bin\$(var.Configuration)\TunnelRelay.exe" />
           </Shortcut>
         </File>
-        <File Id="TunnelRelayUIExeConfig" Source="$(var.TunnelRelay.TargetDir)\$(var.TunnelRelay.TargetName).exe.config" DiskId="1" />
-        <File Id="TunnelRelayUIPdb" Source="$(var.TunnelRelay.TargetDir)\$(var.TunnelRelay.TargetName).pdb" DiskId="1" />
-        <File Id="TunnelRelayUIXml" Source="$(var.TunnelRelay.TargetDir)\$(var.TunnelRelay.TargetName).xml" DiskId="1" />
+        <File Id="TunnelRelayUIExeConfig" Source="..\TunnelRelay\bin\$(var.Configuration)\TunnelRelay.exe.config" DiskId="1" />
+        <File Id="TunnelRelayUIPdb" Source="..\TunnelRelay\bin\$(var.Configuration)\TunnelRelay.pdb" DiskId="1" />
+        <File Id="TunnelRelayUIXml" Source="..\TunnelRelay\bin\$(var.Configuration)\TunnelRelay.xml" DiskId="1" />
 
       </Component>
       <Component Id="TunnelRelayCore" Guid="1B0D63B9-F963-4853-A6A6-3C4BAA2EDC71">
-        <File Id="TunnelRelayCoreDll" Source="$(var.TunnelRelay.Core.TargetPath)" DiskId="1" />
-        <File Id="TunnelRelayCorePdb" Source="$(var.TunnelRelay.Core.TargetDir)\$(var.TunnelRelay.Core.TargetName).pdb" DiskId="1" />
-        <File Id="TunnelRelayCoreXml" Source="$(var.TunnelRelay.Core.TargetDir)\$(var.TunnelRelay.Core.TargetName).xml" DiskId="1" />
-        <File Id="TunnelRelayConfig" Source="$(var.TunnelRelay.TargetDir)\appSettings.Json.default" Name="appSettings.Json" DiskId="1">
+        <File Id="TunnelRelayCoreDll" Source="..\TunnelRelay.Core\bin\$(var.Configuration)\TunnelRelay.Core.dll" DiskId="1" />
+        <File Id="TunnelRelayCorePdb" Source="..\TunnelRelay.Core\bin\$(var.Configuration)\TunnelRelay.Core.pdb" DiskId="1" />
+        <File Id="TunnelRelayCoreXml" Source="..\TunnelRelay.Core\bin\$(var.Configuration)\TunnelRelay.Core.xml" DiskId="1" />
+        <File Id="TunnelRelayConfig" Source="..\TunnelRelay\bin\$(var.Configuration)\appSettings.Json.default" Name="appSettings.Json" DiskId="1">
           <Permission ChangePermission="yes" GenericAll="yes" User="Everyone" TakeOwnership="yes" Write="yes" WriteAttributes="yes" WriteExtendedAttributes="yes" />
         </File>
       </Component>
       <Component Id="TunnelRelayPlugin" Guid="2D4C603E-EA3B-4A6B-8DC8-5075FC9FD7EC">
-        <File Id="TunnelRelayPluginDll" Source="$(var.TunnelRelay.Plugins.TargetPath)" DiskId="1" />
-        <File Id="TunnelRelayPluginPdb" Source="$(var.TunnelRelay.Plugins.TargetDir)\$(var.TunnelRelay.Plugins.TargetName).pdb" DiskId="1" />
-        <File Id="TunnelRelayPluginXml" Source="$(var.TunnelRelay.Plugins.TargetDir)\$(var.TunnelRelay.Plugins.TargetName).xml" DiskId="1" />
+        <File Id="TunnelRelayPluginDll" Source="..\TunnelRelay.Plugins\bin\$(var.Configuration)\TunnelRelay.Plugins.dll" DiskId="1" />
+        <File Id="TunnelRelayPluginPdb" Source="..\TunnelRelay.Plugins\bin\$(var.Configuration)\TunnelRelay.Plugins.pdb" DiskId="1" />
+        <File Id="TunnelRelayPluginXml" Source="..\TunnelRelay.Plugins\bin\$(var.Configuration)\TunnelRelay.Plugins.xml" DiskId="1" />
       </Component>
       <Component Id="NewtonsoftJson" Guid="19B7E2F8-9E4C-40D1-A6A1-499F2576887C">
-        <File Id="NewtonsoftJsonDll" Source="$(var.TunnelRelay.TargetDir)\Newtonsoft.Json.dll" DiskId="1" />
+        <File Id="NewtonsoftJsonDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Newtonsoft.Json.dll" DiskId="1" />
       </Component>
       <Component Id="ServiceBus" Guid="8E112B1B-F187-4495-8F69-BB8B78E1C73E">
-        <File Id="ServiceBusDll" Source="$(var.TunnelRelay.TargetDir)\Microsoft.ServiceBus.dll" DiskId="1" />
+        <File Id="ServiceBusDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Microsoft.ServiceBus.dll" DiskId="1" />
       </Component>
       <Component Id="RestClientRuntime" Guid="28B803DF-DFE3-4DC7-B0B3-007A4A05207D">
-        <File Id="RestClientRuntimeDll" Source="$(var.TunnelRelay.TargetDir)\Microsoft.Rest.ClientRuntime.dll" DiskId="1" />
+        <File Id="RestClientRuntimeDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Microsoft.Rest.ClientRuntime.dll" DiskId="1" />
       </Component>
       <Component Id="RestClientRuntimeAzure" Guid="720E64F0-3677-4FDA-9700-0AEBE6CBBD0F">
-        <File Id="RestClientRuntimeAzureDll" Source="$(var.TunnelRelay.TargetDir)\Microsoft.Rest.ClientRuntime.Azure.dll" DiskId="1" />
+        <File Id="RestClientRuntimeAzureDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Microsoft.Rest.ClientRuntime.Azure.dll" DiskId="1" />
       </Component>
       <Component Id="RestClientRuntimeAzureAuth" Guid="B2C9400F-EB89-4368-A600-F84C3D88C3AB">
-        <File Id="RestClientRuntimeAzureAuthDll" Source="$(var.TunnelRelay.TargetDir)\Microsoft.Rest.ClientRuntime.Azure.Authentication.dll" DiskId="1" />
+        <File Id="RestClientRuntimeAzureAuthDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Microsoft.Rest.ClientRuntime.Azure.Authentication.dll" DiskId="1" />
       </Component>
       <Component Id="Adal" Guid="CD88DA03-66BC-4B91-9358-B1BA19A0595D">
-        <File Id="AdalDll" Source="$(var.TunnelRelay.TargetDir)\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" DiskId="1" />
-        <File Id="AdalDesktopDll" Source="$(var.TunnelRelay.TargetDir)\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" DiskId="1" />
+        <File Id="AdalDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" DiskId="1" />
+        <File Id="AdalDesktopDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" DiskId="1" />
       </Component>
       <Component Id="ServiceBusManagement" Guid="C27DBB35-3EC3-4F31-B386-EE7279B98AEA">
-        <File Id="ServiceBusManagementDll" Source="$(var.TunnelRelay.TargetDir)\Microsoft.Azure.Management.ServiceBus.Fluent.dll" DiskId="1" />
+        <File Id="ServiceBusManagementDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Microsoft.Azure.Management.ServiceBus.Fluent.dll" DiskId="1" />
       </Component>
       <Component Id="ResourceManagerManagement" Guid="3EA25677-E0C9-4B21-B684-204CA4992F9F">
-        <File Id="ResourceManagerManagementDll" Source="$(var.TunnelRelay.TargetDir)\Microsoft.Azure.Management.ResourceManager.Fluent.dll" DiskId="1" />
+        <File Id="ResourceManagerManagementDll" Source="..\TunnelRelay\bin\$(var.Configuration)\Microsoft.Azure.Management.ResourceManager.Fluent.dll" DiskId="1" />
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/Packager/TunnelRelayMSI.wixproj
+++ b/Packager/TunnelRelayMSI.wixproj
@@ -38,32 +38,6 @@
     <Content Include="License.rtf" />
     <Content Include="TRBannerTop.bmp" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\TunnelRelay.Core\TunnelRelay.Core.csproj">
-      <Name>TunnelRelay.Core</Name>
-      <Project>{165bb633-ee2d-473c-9d5c-be92e02fc5ca}</Project>
-      <Private>True</Private>
-      <DoNotHarvest>True</DoNotHarvest>
-      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
-      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
-    </ProjectReference>
-    <ProjectReference Include="..\TunnelRelay.Plugins\TunnelRelay.Plugins.csproj">
-      <Name>TunnelRelay.Plugins</Name>
-      <Project>{5eb32488-8c81-4e8f-acff-2c457f5f95f1}</Project>
-      <Private>True</Private>
-      <DoNotHarvest>True</DoNotHarvest>
-      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
-      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
-    </ProjectReference>
-    <ProjectReference Include="..\TunnelRelay\TunnelRelay.csproj">
-      <Name>TunnelRelay</Name>
-      <Project>{1d6e50c4-1f9f-4f8a-8916-d3aeaba4a8e0}</Project>
-      <Private>True</Private>
-      <DoNotHarvest>True</DoNotHarvest>
-      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
-      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
   <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">


### PR DESCRIPTION
To separate out build and packaging (to enable signing) removing Project reference model and replace it with relative path